### PR TITLE
add hr shortcuts

### DIFF
--- a/shortcuts/hr.yml
+++ b/shortcuts/hr.yml
@@ -1,0 +1,31 @@
+General:
+  - "Back": "Cmd + ["
+  - "Help": "Cmd + ?"
+  - "Menu": "Opt + Cmd + M"
+  - "Preferences": "Cmd + ,"
+  - "Quit": "Cmd + Q"
+  - "Select All": "Cmd + A"
+
+Categories:
+  - "Archive Category": "Ctrl + Cmd + A"
+  - "Create New Category": "Cmd + N"
+  - "Delete Category": "delete"
+  - "Unarchive Category": "Ctrl + Cmd + U"
+
+Tasks:
+  - "Create New Task": "Cmd + N"
+  - "Decrease Priority": "Cmd + -"
+  - "Delete Task": "delete"
+  - "Increase Priority": "Cmd + +"
+  - "Mark/Unmark Task as Complete": "Opt + Cmd + C"
+  - "Show/Hide Complete Tasks": "Shift + Cmd + C"
+  - "Start": "Space"
+
+Sessions:
+  - "Delete Session": "delete"
+  - "View: Sessions": "Cmd + 1"
+  - "View: Task Properties": "Cmd + 2"
+
+Timer:
+  - "Pause": "Space"
+  - "Stop": "Cmd + ."


### PR DESCRIPTION
hr is a menu bar app I find useful to completing all sorts of tasks. Unfortunately to find the keyboard shortcuts you currently need to go to [hr's website](https://hrmacapp.com/#support). Including them in Pretzel definitely makes my life easier. Thanks again for this app :). Also thank you for updating the readme; I was literally rebuilding the .app to get around the dependency issue (not sure how); using `nvm` taught me about virtual envs for node and drastically reduced my dev time. You might want to update the *contributing.md* to reflect this info about using  `nvm install 8.11.3` as well.
![image](https://user-images.githubusercontent.com/8005593/43413039-be7426c2-93e3-11e8-8c50-83c67117096d.png)
